### PR TITLE
Revert "Bump Android Build Tools to 29.0.2 in WORKSPACE (#304)"

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,7 +5,7 @@ load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
 android_sdk_repository(
     name = "androidsdk",
     api_level = 28,
-    build_tools_version = "29.0.2",
+    build_tools_version = "28.0.2",
     # path = "/path/to/sdk",
 )
 


### PR DESCRIPTION
Apparently this project is not compatible with the newer build tools,
as the pipeline has been red on Linux and Windows since the upgrade:

https://buildkite.com/bazel/android-testing/builds/642

This reverts commit f08dda59e6e1c9dafd312b1b0c0ef1188bd6d9fe.