### PR TITLE
RBE worker pool migration

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -46,5 +46,9 @@ platform(
             name: "dockerPrivileged"
             value: "true"
         }
+        properties: {
+            name: "gceMachineType"
+            value: "n1-standard-2"
+        }
 """,
 )


### PR DESCRIPTION
Bazel is migrating its RBE worker pool from n1 machines to e2. We created a new dedicated worker pool with n1 machines to support nested virtualization. This PR updates BRE config to target that dedicated worker pool.