### PR TITLE
Update android SDK api_level to 29.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,8 +4,8 @@ load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
 # Set the path to your local SDK installation, or use the ANDROID_HOME environment variable.
 android_sdk_repository(
     name = "androidsdk",
-    api_level = 28,
-    build_tools_version = "28.0.2",
+    api_level = 29,
+    build_tools_version = "29.0.2",
     # path = "/path/to/sdk",
 )
 


### PR DESCRIPTION
Buildkite continuous integration environment has been updated to api 29, with the old SDKs removed.