### PR TITLE
Incorrect array

### DIFF
--- a/ui/espresso/MultiWindowSample/app/src/main/res/values/strings.xml
+++ b/ui/espresso/MultiWindowSample/app/src/main/res/values/strings.xml
@@ -31,7 +31,7 @@
         <item>Okhotsk Sea</item>
         <item>East China Sea</item>
         <item>Hudson Bay</item>
-        <item>Japan Sea</item>
+        <item>East Sea(Sea of Korea)</item>
         <item>Andaman Sea</item>
         <item>North Sea</item>
         <item>Red Sea</item>


### PR DESCRIPTION
 ### Historically, Sea of Korea, not to be in the "Japan Sea".
 
References  url : http://www.eastseakorea.com/east-sea-information2/