### PR TITLE
Remove ubuntu1604 from buildkite-pipeline.yml

### DIFF
--- a/bazelci/buildkite-pipeline.yml
+++ b/bazelci/buildkite-pipeline.yml
@@ -1,15 +1,6 @@
 # https://github.com/googlesamples/android-testing#experimental-bazel-support
 ---
 platforms:
-  ubuntu1604:
-    build_targets:
-    - "//..."
-    test_flags:
-    - "--config=remote_android"
-    - "--flaky_test_attempts=3"
-    test_targets:
-    - "//..."
-    - "-//ui/espresso/AccessibilitySample/..."
   ubuntu1804:
     build_targets:
     - "//..."


### PR DESCRIPTION
Ubuntu 16.04 is end-of-life, we're going to remove it from Bazel CI.

If you like you can add testing on `ubuntu2004` platform which we also support.