### PR TITLE
Stop running android_instrumentation_test on Bazel CI

### DIFF
--- a/bazelci/buildkite-pipeline.yml
+++ b/bazelci/buildkite-pipeline.yml
@@ -13,7 +13,10 @@ platforms:
   ubuntu1804:
     build_targets:
     - "//..."
+    build_flags:
+    - "--test_lang_filters=-android_instrumentation" # BazelCI does not have Android Emulator
     test_flags:
+    - "--test_lang_filters=-android_instrumentation" # BazelCI does not have Android Emulator
     - "--config=remote_android"
     - "--flaky_test_attempts=3"
     test_targets:


### PR DESCRIPTION
Android Emulator adds complexity to the infrastructure, because the emulator requires access to the /dev/kvm device and enabled Nested Virtualization, which means that basically any CI job could get root on the host VM using that. The mitigations for that make other features very hard to implement.