### PR TITLE
Migrate buildToolVersion to property style

### DIFF
--- a/ui/espresso/DataAdapterSample/app/build.gradle
+++ b/ui/espresso/DataAdapterSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 33
-    buildToolsVersion rootProject.buildToolsVersion
+    buildToolsVersion = rootProject.buildToolsVersion
     defaultConfig {
         applicationId "com.example.android.testing.espresso.DataAdapterSample"
         minSdkVersion 14

--- a/ui/espresso/EspressoDeviceSample/app/build.gradle
+++ b/ui/espresso/EspressoDeviceSample/app/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 33
-    buildToolsVersion rootProject.buildToolsVersion
+    buildToolsVersion = rootProject.buildToolsVersion
     defaultConfig {
         applicationId "com.example.android.testing.espresso.EspressoDeviceSample"
         minSdkVersion 14

--- a/ui/espresso/IdlingResourceSample/app/build.gradle
+++ b/ui/espresso/IdlingResourceSample/app/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 33
-    buildToolsVersion rootProject.buildToolsVersion
+    buildToolsVersion = rootProject.buildToolsVersion
 
     defaultConfig {
         applicationId "com.example.android.testing.espresso.IdlingResourceSample"

--- a/ui/espresso/IntentsAdvancedSample/app/build.gradle
+++ b/ui/espresso/IntentsAdvancedSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 33
-    buildToolsVersion rootProject.buildToolsVersion
+    buildToolsVersion = rootProject.buildToolsVersion
     defaultConfig {
         applicationId "com.example.android.testing.espresso.intents.AdvancedSample"
         minSdkVersion 14

--- a/ui/espresso/IntentsBasicSample/app/build.gradle
+++ b/ui/espresso/IntentsBasicSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 33
-    buildToolsVersion rootProject.buildToolsVersion
+    buildToolsVersion = rootProject.buildToolsVersion
     defaultConfig {
         applicationId "com.example.android.testing.espresso.IntentsBasicSample"
         minSdkVersion 14

--- a/ui/espresso/MultiProcessSample/app/build.gradle
+++ b/ui/espresso/MultiProcessSample/app/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 33
-    buildToolsVersion rootProject.buildToolsVersion
+    buildToolsVersion = rootProject.buildToolsVersion
     defaultConfig {
         applicationId "com.example.android.testing.espresso.multiprocesssample"
         minSdkVersion 14

--- a/ui/espresso/MultiWindowSample/app/build.gradle
+++ b/ui/espresso/MultiWindowSample/app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 33
-    buildToolsVersion rootProject.buildToolsVersion
+    buildToolsVersion = rootProject.buildToolsVersion
     defaultConfig {
         applicationId "com.example.android.testing.espresso.MultiWindowSample"
         minSdkVersion 14

--- a/ui/espresso/RecyclerViewSample/app/build.gradle
+++ b/ui/espresso/RecyclerViewSample/app/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 33
-    buildToolsVersion rootProject.buildToolsVersion
+    buildToolsVersion = rootProject.buildToolsVersion
     defaultConfig {
         applicationId "com.example.android.testing.espresso.RecyclerViewSample"
         minSdkVersion 14

--- a/ui/espresso/WebBasicSample/app/build.gradle
+++ b/ui/espresso/WebBasicSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 33
-    buildToolsVersion rootProject.buildToolsVersion
+    buildToolsVersion = rootProject.buildToolsVersion
     defaultConfig {
         applicationId "com.example.android.testing.espresso.web.BasicSample"
         minSdkVersion 14

--- a/ui/uiautomator/BasicSample/app/build.gradle
+++ b/ui/uiautomator/BasicSample/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 33
-    buildToolsVersion rootProject.buildToolsVersion
+    buildToolsVersion = rootProject.buildToolsVersion
     defaultConfig {
         applicationId "com.example.android.testing.uiautomator.BasicSample"
         minSdkVersion 18

--- a/unit/BasicSample/app/build.gradle
+++ b/unit/BasicSample/app/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 30
-    buildToolsVersion rootProject.buildToolsVersion
+    buildToolsVersion = rootProject.buildToolsVersion
     defaultConfig {
         applicationId "com.example.android.testing.unittesting.BasicSample"
         minSdkVersion 14

--- a/unit/BasicUnitAndroidTest/app/build.gradle
+++ b/unit/BasicUnitAndroidTest/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 30
-    buildToolsVersion rootProject.buildToolsVersion
+    buildToolsVersion = rootProject.buildToolsVersion
 
     defaultConfig {
         applicationId "com.example.android.testing.unittesting.basicunitandroidtest"


### PR DESCRIPTION
The previous function style is deprecated.
See https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-api/src/main/java/com/android/build/api/dsl/CommonExtension.kt;l=723?q=buildToolsVersion&ss=android-studio.