### PR TITLE
Update versions of test dependencies + AGP.

### DIFF
--- a/integration/ServiceTestRuleSample/app/build.gradle
+++ b/integration/ServiceTestRuleSample/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: "com.android.application"
 
 android {
-    compileSdk 33
+    compileSdk 34
     defaultConfig {
         applicationId "com.example.android.testing.integrationtesting.ServiceTestRuleSample"
-        minSdkVersion 14
-        targetSdkVersion 33
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 

--- a/integration/ServiceTestRuleSample/build.gradle
+++ b/integration/ServiceTestRuleSample/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.agpVersion = "8.1.1"
+    ext.agpVersion = "8.5.0"
     repositories {
         // Insert local test repo here
         google()
@@ -24,8 +24,8 @@ allprojects {
 }
 
 ext {
-    coreVersion = "1.6.0-alpha01"
-    extJUnitVersion = "1.2.0-alpha01"
-    runnerVersion = "1.6.0-alpha03"
-    rulesVersion = "1.6.0-alpha01"
+    coreVersion = "1.6.1"
+    extJUnitVersion = "1.2.1"
+    runnerVersion = "1.6.1"
+    rulesVersion = "1.6.1"
 }

--- a/integration/ServiceTestRuleSample/gradle/wrapper/gradle-wrapper.properties
+++ b/integration/ServiceTestRuleSample/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/runner/AndroidJunitRunnerSample/app/build.gradle
+++ b/runner/AndroidJunitRunnerSample/app/build.gradle
@@ -2,11 +2,11 @@ apply plugin: "com.android.application"
 
 
 android {
-    compileSdk 33
+    compileSdk 34
     defaultConfig {
         applicationId "com.example.android.testing.androidjunitrunnersample"
-        minSdkVersion 14
-        targetSdkVersion 33
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 

--- a/runner/AndroidJunitRunnerSample/build.gradle
+++ b/runner/AndroidJunitRunnerSample/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.agpVersion = "8.1.1"
+    ext.agpVersion = "8.5.0"
     repositories {
         // Insert local test repo here
         google()
@@ -27,10 +27,10 @@ ext {
     buildToolsVersion = "32.0.0"
     androidxAnnotationVersion = "1.5.0"
     guavaVersion = "31.1-android"
-    coreVersion = "1.6.0-alpha01"
-    extJUnitVersion = "1.2.0-alpha01"
-    runnerVersion = "1.6.0-alpha03"
-    rulesVersion = "1.6.0-alpha01"
-    espressoVersion = "3.6.0-alpha01"
+    coreVersion = "1.6.1"
+    extJUnitVersion = "1.2.1"
+    runnerVersion = "1.6.1"
+    rulesVersion = "1.6.1"
+    espressoVersion = "3.6.1"
     truthVersion = "1.1.3"
 }

--- a/runner/AndroidJunitRunnerSample/gradle/wrapper/gradle-wrapper.properties
+++ b/runner/AndroidJunitRunnerSample/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/runner/AndroidTestOrchestratorSample/app/build.gradle
+++ b/runner/AndroidTestOrchestratorSample/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: "com.android.application"
 
 android {
-    compileSdk 33
+    compileSdk 34
     defaultConfig {
         applicationId "com.example.android.testing.androidtestorchestratorsample"
-        minSdkVersion 14
-        targetSdkVersion 33
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 

--- a/runner/AndroidTestOrchestratorSample/build.gradle
+++ b/runner/AndroidTestOrchestratorSample/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.agpVersion = "8.1.1"
+    ext.agpVersion = "8.5.0"
     repositories {
         // Insert local test repo here
         google()
@@ -26,12 +26,12 @@ allprojects {
 ext {
     androidxAnnotationVersion = "1.5.0"
     guavaVersion = "31.1-android"
-    coreVersion = "1.6.0-alpha01"
-    extJUnitVersion = "1.2.0-alpha01"
-    runnerVersion = "1.6.0-alpha03"
-    monitorVersion = "1.7.0-alpha01"
-    rulesVersion = "1.6.0-alpha01"
-    espressoVersion = "3.6.0-alpha01"
-    orchestratorVersion = "1.5.0-alpha01"
+    coreVersion = "1.6.1"
+    extJUnitVersion = "1.2.1"
+    runnerVersion = "1.6.1"
+    monitorVersion = "1.7.1"
+    rulesVersion = "1.6.1"
+    espressoVersion = "3.6.1"
+    orchestratorVersion = "1.5.0"
     truthVersion = "1.1.3"
 }

--- a/runner/AndroidTestOrchestratorSample/gradle/wrapper/gradle-wrapper.properties
+++ b/runner/AndroidTestOrchestratorSample/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/runner/AndroidTestOrchestratorWithTestCoverageSample/gradle/wrapper/gradle-wrapper.properties
+++ b/runner/AndroidTestOrchestratorWithTestCoverageSample/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jun 01 11:09:45 PDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/test_all.sh
+++ b/test_all.sh
@@ -9,7 +9,7 @@ for p in $(cat projects.conf); do
    echo "====================================================================="
 
    pushd $p > /dev/null  # Silent pushd
-   ./gradlew $@ testDebug nexusOneApi30DebugAndroidTest --info | sed "s@^@$p @"  # Prefix every line with directory
+   ./gradlew $@ testDebug nexusOneApi30DebugAndroidTest --info --no-watch-fs | sed "s@^@$p @"  # Prefix every line with directory
    code=${PIPESTATUS[0]}
    if [ "$code" -ne "0" ]; then
        exit $code

--- a/ui/espresso/AccessibilitySample/app/build.gradle
+++ b/ui/espresso/AccessibilitySample/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: "com.android.application"
 
 android {
-    compileSdk 33
+    compileSdk 34
     defaultConfig {
         applicationId "com.example.android.testing.espresso.AccessibilitySample"
-        minSdkVersion 14
-        targetSdkVersion 33
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 

--- a/ui/espresso/AccessibilitySample/build.gradle
+++ b/ui/espresso/AccessibilitySample/build.gradle
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlinVersion = "1.7.10"
-    ext.agpVersion = "8.1.1"
+    ext.kotlinVersion = "1.9.22"
+    ext.agpVersion = "8.5.0"
     repositories {
         // Insert local test repo here
         google()
@@ -27,11 +27,11 @@ allprojects {
 
 ext {
     androidxAnnotationVersion = "1.5.0"
-    robolectricVersion = "4.10.3"
-    extTruthVersion = "1.6.0-alpha01"
-    coreVersion = "1.6.0-alpha01"
-    extJUnitVersion = "1.2.0-alpha01"
-    runnerVersion = "1.6.0-alpha03"
-    espressoVersion = "3.6.0-alpha01"
+    robolectricVersion = "4.13"
+    extTruthVersion = "1.6.0"
+    coreVersion = "1.6.1"
+    extJUnitVersion = "1.2.1"
+    runnerVersion = "1.6.1"
+    espressoVersion = "3.6.1"
     guavaVersion = "31.1-android"
 }

--- a/ui/espresso/AccessibilitySample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/espresso/AccessibilitySample/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ui/espresso/BasicSample/app/build.gradle
+++ b/ui/espresso/BasicSample/app/build.gradle
@@ -3,11 +3,11 @@ apply plugin: "com.android.application"
 apply plugin: "kotlin-android"
 
 android {
-    compileSdk 33
+    compileSdk 34
     defaultConfig {
         applicationId "com.example.android.testing.espresso.BasicSample"
-        minSdkVersion 14
-        targetSdkVersion 33
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 

--- a/ui/espresso/BasicSample/build.gradle
+++ b/ui/espresso/BasicSample/build.gradle
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlinVersion = "1.8.20"
-    ext.agpVersion = "8.1.1"
+    ext.kotlinVersion = "1.9.22"
+    ext.agpVersion = "8.5.0"
     repositories {
         // Insert local test repo here
         google()
@@ -27,11 +27,11 @@ allprojects {
 
 ext {
     androidxAnnotationVersion = "1.5.0"
-    robolectricVersion = "4.10.3"
+    robolectricVersion = "4.13"
     guavaVersion = "31.1-android"
-    extTruthVersion = "1.6.0-alpha01"
-    coreVersion = "1.6.0-alpha01"
-    extJUnitVersion = "1.2.0-alpha01"
-    runnerVersion = "1.6.0-alpha03"
-    espressoVersion = "3.6.0-alpha01"
+    extTruthVersion = "1.6.0"
+    coreVersion = "1.6.1"
+    extJUnitVersion = "1.2.1"
+    runnerVersion = "1.6.1"
+    espressoVersion = "3.6.1"
 }

--- a/ui/espresso/BasicSample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/espresso/BasicSample/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ui/espresso/CustomMatcherSample/app/build.gradle
+++ b/ui/espresso/CustomMatcherSample/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: "com.android.application"
 
 android {
-    compileSdk 33
+    compileSdk 34
     defaultConfig {
         applicationId "com.example.android.testing.espresso.CustomMatcherSample"
-        minSdkVersion 14
-        targetSdkVersion 33
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 

--- a/ui/espresso/CustomMatcherSample/build.gradle
+++ b/ui/espresso/CustomMatcherSample/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.agpVersion = "8.1.1"
+    ext.agpVersion = "8.5.0"
     repositories {
         // Insert local test repo here
         google()
@@ -26,10 +26,10 @@ allprojects {
 ext {
     androidxAnnotationVersion = "1.5.0"
     guavaVersion = "31.1-android"
-    coreVersion = "1.6.0-alpha01"
-    extJUnitVersion = "1.2.0-alpha01"
-    runnerVersion = "1.6.0-alpha03"
-    rulesVersion = "1.6.0-alpha01"
-    espressoVersion = "3.6.0-alpha01"
-    robolectricVersion = "4.10.3"
+    coreVersion = "1.6.1"
+    extJUnitVersion = "1.2.1"
+    runnerVersion = "1.6.1"
+    rulesVersion = "1.6.1"
+    espressoVersion = "3.6.1"
+    robolectricVersion = "4.13"
 }

--- a/ui/espresso/CustomMatcherSample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/espresso/CustomMatcherSample/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ui/espresso/DataAdapterSample/app/build.gradle
+++ b/ui/espresso/DataAdapterSample/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: "com.android.application"
 
 android {
-    compileSdk 33
+    compileSdk 34
     defaultConfig {
         applicationId "com.example.android.testing.espresso.DataAdapterSample"
-        minSdkVersion 14
-        targetSdkVersion 33
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/ui/espresso/DataAdapterSample/build.gradle
+++ b/ui/espresso/DataAdapterSample/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.agpVersion = "8.1.1"
+    ext.agpVersion = "8.5.0"
     repositories {
         // Insert local test repo here
         google()
@@ -26,9 +26,9 @@ allprojects {
 ext {
     androidxAnnotationVersion = "1.5.0"
     guavaVersion = "31.1-android"
-    coreVersion = "1.6.0-alpha01"
-    extJUnitVersion = "1.2.0-alpha01"
-    runnerVersion = "1.6.0-alpha03"
-    espressoVersion = "3.6.0-alpha01"
-    robolectricVersion = "4.10.3"
+    coreVersion = "1.6.1"
+    extJUnitVersion = "1.2.1"
+    runnerVersion = "1.6.1"
+    espressoVersion = "3.6.1"
+    robolectricVersion = "4.13"
 }

--- a/ui/espresso/DataAdapterSample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/espresso/DataAdapterSample/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ui/espresso/EspressoDeviceSample/app/build.gradle
+++ b/ui/espresso/EspressoDeviceSample/app/build.gradle
@@ -3,11 +3,11 @@ apply plugin: "com.android.application"
 apply plugin: "kotlin-android"
 
 android {
-    compileSdk 33
+    compileSdk 34
     defaultConfig {
         applicationId "com.example.android.testing.espresso.EspressoDeviceSample"
-        minSdkVersion 19
-        targetSdkVersion 33
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 

--- a/ui/espresso/EspressoDeviceSample/build.gradle
+++ b/ui/espresso/EspressoDeviceSample/build.gradle
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlinVersion = "1.8.20"
-    ext.agpVersion = '8.3.2'
+    ext.kotlinVersion = "1.9.22"
+    ext.agpVersion = "8.5.0"
     repositories {
         // Insert local test repo here
         google()
@@ -26,8 +26,8 @@ allprojects {
 }
 
 ext {
-    robolectricVersion = "4.10.3"
-    extTruthVersion = "1.6.0-alpha04"
-    extJUnitVersion = "1.2.0-alpha04"
+    robolectricVersion = "4.13"
+    extTruthVersion = "1.6.0"
+    extJUnitVersion = "1.2.1"
     espressoDeviceVersion = "1.0.0-alpha09"
 }

--- a/ui/espresso/EspressoDeviceSample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/espresso/EspressoDeviceSample/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ui/espresso/FragmentScenarioSample/app/build.gradle
+++ b/ui/espresso/FragmentScenarioSample/app/build.gradle
@@ -3,11 +3,11 @@ apply plugin: "com.android.application"
 apply plugin: "kotlin-android"
 
 android {
-    compileSdk 33
+    compileSdk 34
     defaultConfig {
         applicationId "com.example.android.testing.espresso.FragmentScenarioSample"
-        minSdkVersion 15
-        targetSdkVersion 33
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/ui/espresso/FragmentScenarioSample/build.gradle
+++ b/ui/espresso/FragmentScenarioSample/build.gradle
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlinVersion = "1.7.10"
-    ext.agpVersion = "8.1.1"
+    ext.kotlinVersion = "1.9.22"
+    ext.agpVersion = "8.5.0"
     repositories {
         google()
         mavenCentral()
@@ -31,11 +31,11 @@ ext {
     androidxCoreVersion = "1.9.0"
     androidxCompatVersion = "1.5.1"
     androidxFragmentVersion = "1.5.3"
-    coreVersion = "1.6.0-alpha01"
-    extJUnitVersion = "1.2.0-alpha01"
-    runnerVersion = "1.6.0-alpha03"
-    rulesVersion = "1.6.0-alpha01"
-    espressoVersion = "3.6.0-alpha01"
-    robolectricVersion = "4.10.3"
+    coreVersion = "1.6.1"
+    extJUnitVersion = "1.2.1"
+    runnerVersion = "1.6.1"
+    rulesVersion = "1.6.1"
+    espressoVersion = "3.6.1"
+    robolectricVersion = "4.13"
     truthVersion = "1.1.3"
 }

--- a/ui/espresso/FragmentScenarioSample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/espresso/FragmentScenarioSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip

--- a/ui/espresso/IdlingResourceSample/app/build.gradle
+++ b/ui/espresso/IdlingResourceSample/app/build.gradle
@@ -17,12 +17,12 @@
 apply plugin: "com.android.application"
 
 android {
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.example.android.testing.espresso.IdlingResourceSample"
-        minSdkVersion 14
-        targetSdkVersion 33
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 

--- a/ui/espresso/IdlingResourceSample/build.gradle
+++ b/ui/espresso/IdlingResourceSample/build.gradle
@@ -17,7 +17,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.agpVersion = "8.1.1"
+    ext.agpVersion = "8.5.0"
     repositories {
         // Insert local test repo here
         google()
@@ -42,8 +42,8 @@ allprojects {
 ext {
     androidxAnnotationVersion = "1.5.0"
     guavaVersion = "31.1-android"
-    coreVersion = "1.6.0-alpha01"
-    extJUnitVersion = "1.2.0-alpha01"
-    runnerVersion = "1.6.0-alpha03"
-    espressoVersion = "3.6.0-alpha01"
+    coreVersion = "1.6.1"
+    extJUnitVersion = "1.2.1"
+    runnerVersion = "1.6.1"
+    espressoVersion = "3.6.1"
 }

--- a/ui/espresso/IdlingResourceSample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/espresso/IdlingResourceSample/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ui/espresso/IntentsAdvancedSample/app/build.gradle
+++ b/ui/espresso/IntentsAdvancedSample/app/build.gradle
@@ -5,8 +5,8 @@ android {
     buildToolsVersion = rootProject.buildToolsVersion
     defaultConfig {
         applicationId "com.example.android.testing.espresso.intents.AdvancedSample"
-        minSdkVersion 14
-        targetSdkVersion 33
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 

--- a/ui/espresso/IntentsAdvancedSample/build.gradle
+++ b/ui/espresso/IntentsAdvancedSample/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.agpVersion = "8.1.1"
+    ext.agpVersion = "8.5.0"
     repositories {
         // Insert local test repo here
         google()
@@ -26,9 +26,9 @@ allprojects {
 ext {
     buildToolsVersion = "32.0.0"
     androidxAnnotationVersion = "1.5.0"
-    coreVersion = "1.6.0-alpha01"
-    extJUnitVersion = "1.2.0-alpha01"
-    runnerVersion = "1.6.0-alpha03"
-    rulesVersion = "1.6.0-alpha01"
-    espressoVersion = "3.6.0-alpha01"
+    coreVersion = "1.6.1"
+    extJUnitVersion = "1.2.1"
+    runnerVersion = "1.6.1"
+    rulesVersion = "1.6.1"
+    espressoVersion = "3.6.1"
 }

--- a/ui/espresso/IntentsAdvancedSample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/espresso/IntentsAdvancedSample/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ui/espresso/IntentsBasicSample/app/build.gradle
+++ b/ui/espresso/IntentsBasicSample/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: "com.android.application"
 
 android {
-    compileSdk 33
+    compileSdk 34
     defaultConfig {
         applicationId "com.example.android.testing.espresso.IntentsBasicSample"
-        minSdkVersion 14
-        targetSdkVersion 33
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 

--- a/ui/espresso/IntentsBasicSample/build.gradle
+++ b/ui/espresso/IntentsBasicSample/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.agpVersion = "8.1.1"
+    ext.agpVersion = "8.5.0"
     repositories {
         // Insert local test repo here
         google()
@@ -26,12 +26,12 @@ allprojects {
 ext {
     androidxAnnotationVersion = "1.5.0"
     androidxCoreVersion = "1.9.0"
-    coreVersion = "1.6.0-alpha01"
-    extJUnitVersion = "1.2.0-alpha01"
-    runnerVersion = "1.6.0-alpha03"
-    rulesVersion = "1.6.0-alpha01"
-    espressoVersion = "3.6.0-alpha01"
-    extJUnitVersion = "1.2.0-alpha01"
-    extTruthVersion = "1.6.0-alpha01"
-    robolectricVersion = "4.10.3"
+    coreVersion = "1.6.1"
+    extJUnitVersion = "1.2.1"
+    runnerVersion = "1.6.1"
+    rulesVersion = "1.6.1"
+    espressoVersion = "3.6.1"
+    extJUnitVersion = "1.2.1"
+    extTruthVersion = "1.6.0"
+    robolectricVersion = "4.13"
 }

--- a/ui/espresso/IntentsBasicSample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/espresso/IntentsBasicSample/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ui/espresso/MultiProcessSample/app/build.gradle
+++ b/ui/espresso/MultiProcessSample/app/build.gradle
@@ -17,11 +17,11 @@
 apply plugin: "com.android.application"
 
 android {
-    compileSdk 33
+    compileSdk 34
     defaultConfig {
         applicationId "com.example.android.testing.espresso.multiprocesssample"
-        minSdkVersion 14
-        targetSdkVersion 33
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 

--- a/ui/espresso/MultiProcessSample/build.gradle
+++ b/ui/espresso/MultiProcessSample/build.gradle
@@ -17,7 +17,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.agpVersion = "8.1.1"
+    ext.agpVersion = "8.5.0"
     repositories {
         // Insert local test repo here
         google()
@@ -45,9 +45,9 @@ task clean(type: Delete) {
 
 ext {
     androidxAnnotationVersion = "1.5.0"
-    coreVersion = "1.6.0-alpha01"
-    extJUnitVersion = "1.2.0-alpha01"
-    runnerVersion = "1.6.0-alpha03"
-    rulesVersion = "1.6.0-alpha01"
-    espressoVersion = "3.6.0-alpha01"
+    coreVersion = "1.6.1"
+    extJUnitVersion = "1.2.1"
+    runnerVersion = "1.6.1"
+    rulesVersion = "1.6.1"
+    espressoVersion = "3.6.1"
 }

--- a/ui/espresso/MultiProcessSample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/espresso/MultiProcessSample/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip

--- a/ui/espresso/MultiWindowSample/app/build.gradle
+++ b/ui/espresso/MultiWindowSample/app/build.gradle
@@ -2,11 +2,11 @@
 apply plugin: "com.android.application"
 
 android {
-    compileSdk 33
+    compileSdk 34
     defaultConfig {
         applicationId "com.example.android.testing.espresso.MultiWindowSample"
-        minSdkVersion 14
-        targetSdkVersion 33
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/ui/espresso/MultiWindowSample/build.gradle
+++ b/ui/espresso/MultiWindowSample/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.agpVersion = "8.1.1"
+    ext.agpVersion = "8.5.0"
     repositories {
         // Insert local test repo here
         google()
@@ -27,10 +27,10 @@ ext {
     buildToolsVersion = "32.0.0"
     androidxAnnotationVersion = "1.5.0"
     guavaVersion = "31.1-android"
-    coreVersion = "1.6.0-alpha01"
-    extJUnitVersion = "1.2.0-alpha01"
-    runnerVersion = "1.6.0-alpha03"
-    rulesVersion = "1.6.0-alpha01"
-    espressoVersion = "3.6.0-alpha01"
+    coreVersion = "1.6.1"
+    extJUnitVersion = "1.2.1"
+    runnerVersion = "1.6.1"
+    rulesVersion = "1.6.1"
+    espressoVersion = "3.6.1"
 }
 

--- a/ui/espresso/MultiWindowSample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/espresso/MultiWindowSample/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ui/espresso/RecyclerViewSample/app/build.gradle
+++ b/ui/espresso/RecyclerViewSample/app/build.gradle
@@ -17,11 +17,11 @@
 apply plugin: "com.android.application"
 
 android {
-    compileSdk 33
+    compileSdk 34
     defaultConfig {
         applicationId "com.example.android.testing.espresso.RecyclerViewSample"
-        minSdkVersion 14
-        targetSdkVersion 33
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 

--- a/ui/espresso/RecyclerViewSample/build.gradle
+++ b/ui/espresso/RecyclerViewSample/build.gradle
@@ -17,7 +17,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.agpVersion = "8.1.1"
+    ext.agpVersion = "8.5.0"
     repositories {
         // Insert local test repo here
         google()
@@ -43,9 +43,9 @@ ext {
     androidxAnnotationVersion = "1.5.0"
     androidxRecyclerVersion = "1.2.1"
     guavaVersion = "31.1-android"
-    coreVersion = "1.6.0-alpha01"
-    extJUnitVersion = "1.2.0-alpha01"
-    runnerVersion = "1.6.0-alpha03"
-    rulesVersion = "1.6.0-alpha01"
-    espressoVersion = "3.6.0-alpha01"
+    coreVersion = "1.6.1"
+    extJUnitVersion = "1.2.1"
+    runnerVersion = "1.6.1"
+    rulesVersion = "1.6.1"
+    espressoVersion = "3.6.1"
 }

--- a/ui/espresso/RecyclerViewSample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/espresso/RecyclerViewSample/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ui/espresso/ScreenshotSample/app/build.gradle
+++ b/ui/espresso/ScreenshotSample/app/build.gradle
@@ -5,12 +5,12 @@ plugins {
 apply plugin: "kotlin-android"
 
 android {
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.example.android.testing.espresso.screenshotsample"
         minSdk 19
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 

--- a/ui/espresso/ScreenshotSample/build.gradle
+++ b/ui/espresso/ScreenshotSample/build.gradle
@@ -1,16 +1,16 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.agpVersion = '8.3.2'
-    ext.kotlinVersion = "1.8.20"
+    ext.agpVersion = "8.5.0"
+    ext.kotlinVersion = "1.9.22"
     ext.androidxCoreVersion = "1.9.0"
     ext.buildToolsVersion = "32.0.0"
     ext.androidxCompatVersion = "1.5.1"
-    ext.coreVersion = "1.6.0-alpha06"
-    ext.extJUnitVersion = "1.2.0-alpha04"
-    ext.runnerVersion = "1.6.0-alpha07"
-    ext.rulesVersion = "1.6.0-alpha04"
-    ext.espressoVersion = "3.6.0-alpha04"
-    ext.servicesVersion = "1.5.0-alpha04"
+    ext.coreVersion = "1.6.1"
+    ext.extJUnitVersion = "1.2.1"
+    ext.runnerVersion = "1.6.1"
+    ext.rulesVersion = "1.6.1"
+    ext.espressoVersion = "3.6.1"
+    ext.servicesVersion = "1.5.0"
     ext.truthVersion = "1.1.3"
 
     repositories {

--- a/ui/espresso/ScreenshotSample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/espresso/ScreenshotSample/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Sep 30 12:30:46 PDT 2021
+#Thu Aug 01 20:15:00 UTC 2024
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/ui/espresso/WebBasicSample/app/build.gradle
+++ b/ui/espresso/WebBasicSample/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: "com.android.application"
 
 android {
-    compileSdk 33
+    compileSdk 34
     defaultConfig {
         applicationId "com.example.android.testing.espresso.web.BasicSample"
-        minSdkVersion 14
-        targetSdkVersion 33
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 

--- a/ui/espresso/WebBasicSample/build.gradle
+++ b/ui/espresso/WebBasicSample/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.agpVersion = "8.1.1"
+    ext.agpVersion = "8.5.0"
     repositories {
         // Insert local test repo here
         google()
@@ -26,9 +26,9 @@ allprojects {
 ext {
     androidxAnnotationVersion = "1.5.0"
     guavaVersion = "31.1-android"
-    coreVersion = "1.6.0-alpha01"
-    extJUnitVersion = "1.2.0-alpha01"
-    runnerVersion = "1.6.0-alpha03"
-    rulesVersion = "1.6.0-alpha01"
-    espressoVersion = "3.6.0-alpha01"
+    coreVersion = "1.6.1"
+    extJUnitVersion = "1.2.1"
+    runnerVersion = "1.6.1"
+    rulesVersion = "1.6.1"
+    espressoVersion = "3.6.1"
 }

--- a/ui/espresso/WebBasicSample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/espresso/WebBasicSample/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ui/uiautomator/BasicSample/app/build.gradle
+++ b/ui/uiautomator/BasicSample/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: "com.android.application"
 
 android {
-    compileSdk 33
+    compileSdk 34
     defaultConfig {
         applicationId "com.example.android.testing.uiautomator.BasicSample"
-        minSdkVersion 18
-        targetSdkVersion 33
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 

--- a/ui/uiautomator/BasicSample/build.gradle
+++ b/ui/uiautomator/BasicSample/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.agpVersion = "8.1.1"
+    ext.agpVersion = "8.5.0"
     repositories {
         // Insert local test repo here
         google()
@@ -24,10 +24,10 @@ ext {
     buildToolsVersion = "32.0.0"
     androidxAnnotationVersion = "1.5.0"
     guavaVersion = "31.1-android"
-    coreVersion = "1.6.0-alpha01"
-    extJUnitVersion = "1.2.0-alpha01"
-    runnerVersion = "1.6.0-alpha03"
-    rulesVersion = "1.6.0-alpha01"
-    espressoVersion = "3.6.0-alpha01"
-    uiAutomatorVersion = "2.2.0"
+    coreVersion = "1.6.1"
+    extJUnitVersion = "1.2.1"
+    runnerVersion = "1.6.1"
+    rulesVersion = "1.6.1"
+    espressoVersion = "3.6.1"
+    uiAutomatorVersion = "2.3.0"
 }

--- a/ui/uiautomator/BasicSample/gradle/wrapper/gradle-wrapper.properties
+++ b/ui/uiautomator/BasicSample/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/unit/BasicUnitAndroidTest/gradle/wrapper/gradle-wrapper.properties
+++ b/unit/BasicUnitAndroidTest/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/update_versions.sh
+++ b/update_versions.sh
@@ -9,10 +9,11 @@ set -ex  # Exit immediately if a command exits with a non-zero status.
 #repourl="https:\/\/oss.sonatype.org\/content\/repositories\/orgrobolectric-1216"
 #repourl="http:\/\/localhost:1480"
 # Versions:                             # axt_versions.bzl equivalents
-agpVersion="8.1.0"
-kotlinVersion="1.8.20"                  # KOTLIN_VERSION
-compileSdk="33"
-targetSdkVersion="33"
+agpVersion="8.5.0"
+kotlinVersion="1.9.22"                  # KOTLIN_VERSION
+compileSdk="34"
+minSdkVersion="21"
+targetSdkVersion="34"
 androidxAnnotationVersion="1.5.0"       # ANDROIDX_ANNOTATION_VERSION
 androidxCompatVersion="1.5.1"           # ANDROIDX_COMPAT_VERSION
 androidxCoreVersion="1.9.0"             # ANDROIDX_CORE_VERSION
@@ -20,18 +21,18 @@ androidxFragmentVersion="1.5.3"         # ANDROIDX_FRAGMENT_VERSION
 androidxRecyclerVersion="1.2.1"         # ANDROIDX_RECYCLERVIEW_VERSION
 guavaVersion="31.1-android"           # GUAVA_VERSION
 truthVersion="1.1.3"                    # TRUTH_VERSION
-runnerVersion="1.6.0-alpha03"           # RUNNER_VERSION
-monitorVersion="1.7.0-alpha01"          # MONITOR_VERSION
-rulesVersion="1.6.0-alpha01"            # RULES_VERSION
-servicesVersion="1.5.0-alpha01"         # SERVICES_VERSION
-orchestratorVersion="1.5.0-alpha01"     # ORCHESTRATOR_VERSION
-coreVersion="1.6.0-alpha01"             # CORE_VERSION
-extJUnitVersion="1.2.0-alpha01"         # ANDROIDX_JUNIT_VERSION
-extTruthVersion="1.6.0-alpha01"         # ANDROIDX_TRUTH_VERSION
-espressoVersion="3.6.0-alpha01"         # ESPRESSO_VERSION
-espressoDeviceVersion="1.0.0-alpha04"  # ESPRESSO_DEVICE_VERSION
-robolectricVersion="4.10.3"
-uiAutomatorVersion="2.2.0"              # UIAUTOMATOR_VERSION
+runnerVersion="1.6.1"           # RUNNER_VERSION
+monitorVersion="1.7.1"          # MONITOR_VERSION
+rulesVersion="1.6.1"            # RULES_VERSION
+servicesVersion="1.5.0"         # SERVICES_VERSION
+orchestratorVersion="1.5.0"     # ORCHESTRATOR_VERSION
+coreVersion="1.6.1"             # CORE_VERSION
+extJUnitVersion="1.2.1"         # ANDROIDX_JUNIT_VERSION
+extTruthVersion="1.6.0"         # ANDROIDX_TRUTH_VERSION
+espressoVersion="3.6.1"         # ESPRESSO_VERSION
+espressoDeviceVersion="1.0.1"  # ESPRESSO_DEVICE_VERSION
+robolectricVersion="4.13"
+uiAutomatorVersion="2.3.0"              # UIAUTOMATOR_VERSION
 
 for p in $(cat projects.conf); do
    echo
@@ -60,6 +61,7 @@ for p in $(cat projects.conf); do
    sed -i "s/guavaVersion = \([\"']\).*\1/guavaVersion = \"$guavaVersion\"/" build.gradle
    sed -i "s/truthVersion = \([\"']\).*\1/truthVersion = \"$truthVersion\"/" build.gradle
    sed -i "s/compileSdk .*/compileSdk $compileSdk/" app/build.gradle
+   sed -i "s/minSdkVersion .*/minSdkVersion $minSdkVersion/" app/build.gradle
    sed -i "s/targetSdkVersion .*/targetSdkVersion $targetSdkVersion/" app/build.gradle
    sed -i "s/uiAutomatorVersion = \([\"']\).*\1/uiAutomatorVersion = \"$uiAutomatorVersion\"/" build.gradle
    sed -i "s/robolectricVersion = \([\"']\).*\1/robolectricVersion = \"$robolectricVersion\"/" build.gradle


### PR DESCRIPTION
Update to:
 - latest stable releases for androidx.test.*
 - robolectric 4.13
 - AGP 8.5.0
 - minSdk 21
 - compileSdk + targetSdk 34
 - kotlin 1.9.22

 Also use -no-watch-fs in test-all.sh to reduce filesystem related logspan